### PR TITLE
style: Improve spacing below SampleButton on small screens

### DIFF
--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -25,6 +25,7 @@ export const SampleButton = styled(BaseButton)`
   @media (max-width: 500px) {
     font-size: 0.9rem;
     padding: 0.4rem 0.75rem;
+    margin-bottom: 0.5rem;
   }
 `;
 


### PR DESCRIPTION
This PR improves the spacing between the "Load Sample Expenses" button and the filters on small screens by adding a margin-bottom inside a media query. This enhances readability and prevents layout overlap on narrow viewports.